### PR TITLE
Add insertPragma option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 {..., loader: 'jsx-loader'}
 ```
 
-To enable ES6 features, use `?harmony` in your loader config.
+To enable ES6 features, use `?harmony` in your loader config. To auto insert the pragma required to process the file use the insertPragma parameter e.g. `?insertPragma=React.DOM`.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {
   this.cacheable();
+
   var query = loaderUtils.parseQuery(this.query);
-  return reactTools.transform(source, query);
+  if (query.insertPragma) {
+    source = '/** @jsx ' + query.insertPragma + ' */' + source;
+  }
+
+  return reactTools.transform(source, {
+    harmony: query.harmony
+  });
 };


### PR DESCRIPTION
I thought it would be useful to automatically insert the pragma as you probably want all jsx files to be processed e.g.

``` javascript
{ test: /\.jsx$/, loader: 'jsx-loader?insertPragma' }
```
