### PR TITLE
Added es5 query param support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function(source) {
   }
 
   return reactTools.transform(source, {
-    harmony: query.harmony
+    harmony: query.harmony,
+    es5: query.es5
   });
 };


### PR DESCRIPTION
@petehunt this enables some feature for underlying jstransform options. See https://github.com/facebook/jstransform/blob/master/visitors/es6-class-visitors.js#L146
So that this could work:

``` JavaScript
class A
   get isEmpty () { return true; }// this is a getter property
```
