### PR TITLE
Use this.sourceMap instead of query.sourceMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(source) {
   var transform = reactTools.transformWithDetails(source, {
     harmony: query.harmony,
     es5: query.es5,
-    sourceMap: query.sourceMap
+    sourceMap: this.sourceMap
   });
   if (transform.sourceMap) {
     transform.sourceMap.sources = [sourceFilename];


### PR DESCRIPTION
Webpack already [gives us this.sourceMap](https://github.com/petehunt/jsx-loader/pull/19#issuecomment-53692088), so we should use it.  
It will be `false` if user doesn't emit source maps in config.
