### PR TITLE
Cleanup react-tools update and pass down query params as transform options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,17 +6,10 @@ module.exports = function(source) {
 
   var sourceFilename = loaderUtils.getRemainingRequest(this);
   var current = loaderUtils.getCurrentRequest(this);
+  var transformOptions = loaderUtils.parseQuery(this.query);
 
-  var query = loaderUtils.parseQuery(this.query);
-  if (query.insertPragma) {
-    source = '/** @jsx ' + query.insertPragma + ' */' + source;
-  }
-
-  var transform = reactTools.transformWithDetails(source, {
-    harmony: query.harmony,
-    es5: query.es5,
-    sourceMap: this.sourceMap
-  });
+  transformOptions.sourceMap = this.sourceMap;
+  var transform = reactTools.transformWithDetails(source, transformOptions);
   if (transform.sourceMap) {
     transform.sourceMap.sources = [sourceFilename];
     transform.sourceMap.file = current;


### PR DESCRIPTION
adds support for `stripTypes`
removes `insertPragma`
