### PR TITLE
Describe stripTypes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@
 {..., loader: 'jsx-loader'}
 ```
 
-To enable ES6 features, use `?harmony` in your loader config. To auto insert the pragma required to process the file use the insertPragma parameter e.g. `?insertPragma=React.DOM`.
+To enable ES6 features, use `?harmony` in your loader config. To auto insert the pragma required to process the file use the insertPragma parameter e.g. `?insertPragma=React.DOM`. [Flow]-style type annotations can be stripped using `?stripTypes`.
+
+
+[Flow]: http://flowtype.org/


### PR DESCRIPTION
This just tells people that `stripTypes` exists in the README.

Alternatively, it might be a good idea to just pass through everything (and say so in the README).
