### PR TITLE
Improving the clarity of errors that occur during the JSX transformation

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,17 @@ module.exports = function(source) {
     source = '/** @jsx ' + query.insertPragma + ' */' + source;
   }
 
-  var transform = reactTools.transformWithDetails(source, {
-    harmony: query.harmony,
-    stripTypes: query.stripTypes,
-    es5: query.es5,
-    sourceMap: this.sourceMap
-  });
+  try {
+    var transform = reactTools.transformWithDetails(source, {
+      harmony: query.harmony,
+      stripTypes: query.stripTypes,
+      es5: query.es5,
+      sourceMap: this.sourceMap
+    });
+  } catch(err) {
+    err.message = 'JSX loader failed on ' + sourceFilename + ': ' + err.message;
+    throw err;
+  }
   if (transform.sourceMap) {
     transform.sourceMap.sources = [sourceFilename];
     transform.sourceMap.file = current;


### PR DESCRIPTION
We're bundling components which are split across multiple files, unfortunately syntax errors in require'd files are throwing opaque errors which only report the line number and not the file. This pull request intercepts the errors and prepends the path to the file.

**Before**
`Error: ModuleBuildError: Module build failed: Error: Parse Error: Line 15: Unexpected token ?`

**After**
`Error: ModuleBuildError: Module build failed: Error: JSX loader failed on /Users/markfinger/Projects/bundanon-trust/crm/static/crm/jsx/contact_search/CheckboxFilter.jsx: Parse Error: Line 15: Unexpected token ?`