### PR TITLE
Bind major version of react-tool with jsx-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-loader",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "JSX loader for webpack",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "JSX loader for webpack",
   "main": "index.js",
   "dependencies": {
-    "react-tools": ">=0.12.1",
     "loader-utils": "^0.2.2"
+  },
+  "peerDependencies": {
+    "react-tool": "^0.12.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
so ideally we want to have backward compatibility package version when `react` `react-tool` being updated, but if there are breaking changes, we want to bump the version not to break the existing project.

This PR bind `jsx-loader` 0.12.x with `react-tool` 0.12.x