### PR TITLE
omnipull

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 {..., loader: 'jsx-loader'}
 ```
 
-To enable ES6 features, use `?harmony` in your loader config. To auto insert the pragma required to process the file use the insertPragma parameter e.g. `?insertPragma=React.DOM`. [Flow]-style type annotations can be stripped using `?stripTypes`.
+To enable ES6 features, use `?harmony` and/or `?es6module` in your loader config.
+To auto insert the pragma required to process the file use the insertPragma parameter
+e.g. `?insertPragma=React.DOM`. [Flow]-style type annotations can be stripped using `?stripTypes`.
 
+This fork has been updated to apply source maps from previous loaders to the source map output by
+`react-tools`.
 
 [Flow]: http://flowtype.org/

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function(source) {
 
   var transform = reactTools.transformWithDetails(source, {
     harmony: query.harmony,
+    es6module: query.es6module,
     stripTypes: query.stripTypes,
     es5: query.es5,
     sourceMap: this.sourceMap

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 var reactTools = require('react-tools');
 var loaderUtils = require('loader-utils');
 
-module.exports = function(source) {
+// source map support added by Ben Mosher. #Apache2ChangeNotice
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
+var SourceMapConsumer = require('source-map').SourceMapConsumer;
+
+module.exports = function(source, incomingMap) {
   this.cacheable && this.cacheable();
 
-  var sourceFilename = loaderUtils.getRemainingRequest(this);
   var current = loaderUtils.getCurrentRequest(this);
 
   var query = loaderUtils.parseQuery(this.query);
@@ -19,10 +22,19 @@ module.exports = function(source) {
     es5: query.es5,
     sourceMap: this.sourceMap
   });
-  if (transform.sourceMap) {
-    transform.sourceMap.sources = [sourceFilename];
-    transform.sourceMap.file = current;
-    transform.sourceMap.sourcesContent = [source];
+
+  var outgoingMap = transform.sourceMap;
+  if (outgoingMap) {
+    outgoingMap.sources = [this.resourcePath];
+    outgoingMap.file = current;
+    outgoingMap.sourcesContent = [source];
   }
-  this.callback(null, transform.code, transform.sourceMap);
+
+  if (incomingMap) {
+    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(outgoingMap));
+    generator.applySourceMap(new SourceMapConsumer(incomingMap));
+    outgoingMap = JSON.parse(generator.toString());
+  }
+
+  this.callback(null, transform.code, outgoingMap);
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var reactTools = require('react-tools');
 var loaderUtils = require('loader-utils');
 
+var assign = require('object-assign');
+
 // source map support added by Ben Mosher. #Apache2ChangeNotice
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
@@ -15,13 +17,8 @@ module.exports = function(source, incomingMap) {
     source = '/** @jsx ' + query.insertPragma + ' */' + source;
   }
 
-  var transform = reactTools.transformWithDetails(source, {
-    harmony: query.harmony,
-    es6module: query.es6module,
-    stripTypes: query.stripTypes,
-    es5: query.es5,
-    sourceMap: this.sourceMap
-  });
+  var transform = reactTools.transformWithDetails(source,
+    assign(query, {sourceMap: this.sourceMap}));
 
   var outgoingMap = transform.sourceMap;
   if (outgoingMap) {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.13.1",
   "description": "JSX loader for webpack",
   "main": "index.js",
+  "peerDependencies": {
+    "react-tools": ">=0.13.1"
+  },
   "dependencies": {
-    "react-tools": ">=0.13.1",
     "loader-utils": "^0.2.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "react-tools": ">=0.13.1"
   },
   "dependencies": {
-    "loader-utils": "^0.2.2"
+    "loader-utils": "^0.2.2",
+    "source-map": "^0.4.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.2",
+    "object-assign": "^2.0.0",
     "source-map": "^0.4.2"
   },
   "scripts": {


### PR DESCRIPTION
- Moves `react-tools` to peer dependencies.
- Passes all query parameters through.
- Applies source map from JSX transpilation to incoming map (preserving previous source content).