### PR TITLE
Allowing all React Tools command-line options to be passed in webpack loader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@
 
 To enable ES6 features, use `?harmony` in your loader config. To auto insert the pragma required to process the file use the insertPragma parameter e.g. `?insertPragma=React.DOM`. [Flow]-style type annotations can be stripped using `?stripTypes`.
 
+Additionally, any valid [React Tools command-line options](https://github.com/facebook/react/blob/master/npm-react-tools/README.md#command-line) can be specified as loader config options.
 
-[Flow]: http://flowtype.org/
+Flow: http://flowtype.org/

--- a/index.js
+++ b/index.js
@@ -6,18 +6,11 @@ module.exports = function(source) {
 
   var sourceFilename = loaderUtils.getRemainingRequest(this);
   var current = loaderUtils.getCurrentRequest(this);
+  var transformOptions = loaderUtils.parseQuery(this.query);
+  transformOptions.sourceMap = this.sourceMap;
 
-  var query = loaderUtils.parseQuery(this.query);
-  if (query.insertPragma) {
-    source = '/** @jsx ' + query.insertPragma + ' */' + source;
-  }
+  var transform = reactTools.transformWithDetails(source, transformOptions);
 
-  var transform = reactTools.transformWithDetails(source, {
-    harmony: query.harmony,
-    stripTypes: query.stripTypes,
-    es5: query.es5,
-    sourceMap: this.sourceMap
-  });
   if (transform.sourceMap) {
     transform.sourceMap.sources = [sourceFilename];
     transform.sourceMap.file = current;


### PR DESCRIPTION
This enables passing all React Tools options, like target=es3, which was our motivation for this pull request.