### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "jsx"
   ],
   "author": "Pete Hunt",
-  "license": "Apache 2"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Updating license to "Apache-2.0" per https://spdx.org/licenses/